### PR TITLE
fix: remove devtools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     libfreetype6-dev \
     libpng-dev \
     libtiff5-dev \
-    libjpeg-dev
+    libjpeg-dev \
+    default-jdk
 
 RUN apt-get update && \
     apt-get upgrade -y && \
@@ -32,9 +33,7 @@ COPY www/ ./www/
 COPY utils/ ./utils/
 
 # Install renv & restore packages
-RUN R -e "install.packages('devtools', repos = c(CRAN = 'https://cloud.r-project.org'))"
-ENV RENV_VERSION 0.9.3
-RUN R -e "devtools::install_version('renv', '${RENV_VERSION}', repos = c(CRAN = 'https://cloud.r-project.org'))"
+RUN R -e "install.packages('renv', repos = c(CRAN = 'https://cloud.r-project.org'))"
 RUN Rscript -e 'renv::consent(provided=TRUE)'
 RUN Rscript -e 'renv::restore()'
 

--- a/renv.lock
+++ b/renv.lock
@@ -65,7 +65,7 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.6",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "dbb5e436998a7eba5a9d682060533338"
@@ -366,7 +366,7 @@
     },
     "httpuv": {
       "Package": "httpuv",
-      "Version": "1.5.4",
+      "Version": "1.6.11",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "4e6dabb220b006ccdc3b3b5ff993b205"


### PR DESCRIPTION
This PR removes the `devtools` dependency in the Docker to get it to build successfully again