### PR TITLE
ASA-173: Remove NA players to prevent datatable rendering failure

### DIFF
--- a/utils/players/server_utils.R
+++ b/utils/players/server_utils.R
@@ -49,7 +49,7 @@ players_rv_to_violins_df <- function(page, players_rv) {
 
     if (all(class(df) == "try-error")) {
         stopApp()
-    } else if (class(df) == "list") {
+    } else if ("list" %in% class(df)) {
         return(df)
     }
 

--- a/utils/tables/server_utils.R
+++ b/utils/tables/server_utils.R
@@ -158,7 +158,7 @@ tables_rv_to_df <- function(page, tables_rv, client_timezone, database_timezone 
 
     if (all(class(df) == "try-error")) {
         stopApp()
-    } else if (class(df) == "list") {
+    } else if ("list" %in% class(df)) {
         return(df)
     }
 


### PR DESCRIPTION
Closes #173 
I thought I had checked every page since the previous PR (#172) but while testing upgrades to R from API, I found the datatable didnt load for xGoals for USL1 and MLSNP. In the current version of the App, we just have the player with no name but since we updated DT package, the plugin `diacritics-neutralise` doesn't like NA values, so the datatable doesn't render. 

Current app:
<img width="1088" height="733" alt="Screenshot 2025-12-24 at 8 40 47 AM" src="https://github.com/user-attachments/assets/f6346307-e22f-4bd4-a111-52c3750460e5" />


To see this data issue you can run:
```
league <- "mlsnp"
goals_added <- api_request(endpoint = assemble_endpoint(league, route_prefix = "goals-added", subheader = "players"))
players <- api_request(endpoint = assemble_endpoint(league, subheader = "players"))

df <- goals_added |> 
  dplyr::left_join(players, by = "player_id")

df |> dplyr::filter(is.na(player_name)) |> dplyr::count()
       n
   <int>
1:     1
```

This PR just filters out any player with no name. If there is another suggestion or route you all would prefer, I'm happy to adjust.

To test this branch run:
./build.sh 
or 
renv::restore()
shiny::runApp()