### PR TITLE
Issue 182 Fix styling issues introduced in #172

### DIFF
--- a/utils/players/ui_utils.R
+++ b/utils/players/ui_utils.R
@@ -32,7 +32,8 @@ profiles_players_header <- function(page, players_rv, all_players) {
                               ifelse(is.na(player_dict$weight_lb), "", paste0(" &nbsp;|&nbsp; Weight: ", player_dict$weight_lb, " lbs"))))),
                 p(player_dict$home_town, player_dict$birth_place))
         ),
-        width = 12
+        width = 12,
+        collapsible = FALSE
     )
 }
 
@@ -154,7 +155,8 @@ violin_plots_profiles_players <- function(page, players_rv) {
     if (!is.data.frame(df)) {
         bs4Card(
             p("Search yielded zero results."),
-            width = 12
+            width = 12,
+            collapsible = FALSE
         )
     } else {
         bs4Card(
@@ -303,7 +305,8 @@ violin_plots_profiles_players <- function(page, players_rv) {
                               league)
                 )
             ),
-            width = 12
+            width = 12,
+            collapsible = FALSE
         )
     }
 }

--- a/utils/tables/reactive_values.R
+++ b/utils/tables/reactive_values.R
@@ -27,7 +27,7 @@ for (l in league_schemas) {
         fixed_columns = list(leftColumns = 2),
         column_defs = list(list(width = "55px", targets = 0),
                            list(orderable = FALSE, targets = 0),
-                           list(className = "min-tablet-p", targets = 0))
+                           list(className = "all", targets = 0))
     )
 
     tables_rv[[paste0(l, "/xgoals/teams")]] <- list(
@@ -48,7 +48,7 @@ for (l in league_schemas) {
         fixed_columns = list(leftColumns = 2),
         column_defs = list(list(width = "40px", targets = 0),
                            list(orderable = FALSE, targets = 0),
-                           list(className = "min-tablet-p", targets = 0))
+                           list(className = "all", targets = 0))
     )
 
     tables_rv[[paste0(l, "/xgoals/games")]] <- list(
@@ -80,7 +80,7 @@ for (l in league_schemas) {
         fixed_columns = list(leftColumns = 2),
         column_defs = list(list(width = "55px", targets = 0),
                            list(orderable = FALSE, targets = 0),
-                           list(className = "min-tablet-p", targets = 0))
+                           list(className = "all", targets = 0))
     )
 
 
@@ -103,7 +103,7 @@ for (l in league_schemas) {
         fixed_columns = list(leftColumns = 2),
         column_defs = list(list(width = "55px", targets = 0),
                            list(orderable = FALSE, targets = 0),
-                           list(className = "min-tablet-p", targets = 0))
+                           list(className = "all", targets = 0))
     )
 
     tables_rv[[paste0(l, "/xpass/teams")]] <- list(
@@ -121,7 +121,7 @@ for (l in league_schemas) {
         fixed_columns = list(leftColumns = 2),
         column_defs = list(list(width = "40px", targets = 0),
                            list(orderable = FALSE, targets = 0),
-                           list(className = "min-tablet-p", targets = 0))
+                           list(className = "all", targets = 0))
     )
 
 
@@ -144,7 +144,7 @@ for (l in league_schemas) {
         fixed_columns = list(leftColumns = 2),
         column_defs = list(list(width = "55px", targets = 0),
                            list(orderable = FALSE, targets = 0),
-                           list(className = "min-tablet-p", targets = 0))
+                           list(className = "all", targets = 0))
     )
 
     tables_rv[[paste0(l, "/goals-added/goalkeepers")]] <- list(
@@ -164,7 +164,7 @@ for (l in league_schemas) {
         fixed_columns = list(leftColumns = 2),
         column_defs = list(list(width = "55px", targets = 0),
                            list(orderable = FALSE, targets = 0),
-                           list(className = "min-tablet-p", targets = 0))
+                           list(className = "all", targets = 0))
     )
 
     tables_rv[[paste0(l, "/goals-added/teams")]] <- list(
@@ -179,7 +179,7 @@ for (l in league_schemas) {
         fixed_columns = list(leftColumns = 2),
         column_defs = list(list(width = "40px", targets = 0),
                            list(orderable = FALSE, targets = 0),
-                           list(className = "min-tablet-p", targets = 0))
+                           list(className = "all", targets = 0))
     )
 
 
@@ -196,7 +196,7 @@ for (l in league_schemas) {
             fixed_columns = list(leftColumns = 2),
             column_defs = list(list(width = "55px", targets = 0),
                                list(orderable = FALSE, targets = 0),
-                               list(className = "min-tablet-p", targets = 0))
+                               list(className = "all", targets = 0))
         )
 
         tables_rv[[paste0(l, "/salaries/teams")]] <- list(
@@ -208,7 +208,7 @@ for (l in league_schemas) {
             fixed_columns = list(leftColumns = 2),
             column_defs = list(list(width = "40px", targets = 0),
                                list(orderable = FALSE, targets = 0),
-                               list(className = "min-tablet-p", targets = 0))
+                               list(className = "all", targets = 0))
         )
     }
 }

--- a/utils/tables/ui_utils.R
+++ b/utils/tables/ui_utils.R
@@ -26,7 +26,8 @@ tables_header <- function(page, tab_config) {
             class = "header_background",
             h2(display_name)
         ),
-        width = 12
+        width = 12,
+        collapsible = FALSE
     )
 }
 
@@ -62,7 +63,8 @@ tables_subheader <- function(page, tab_config) {
                 })
             )
         ),
-        width = 12
+        width = 12,
+        collapsible = FALSE
     )
 }
 
@@ -87,7 +89,8 @@ tables_body <- function(page, client_timezone, tables_rv, filtering_hint_ind) {
     if (!is.data.frame(df)) {
         bs4Card(
             p("Search yielded zero results."),
-            width = 12
+            width = 12,
+            collapsible = FALSE
         )
     } else {
         df <- df %>% select(-contains("actions"))
@@ -118,7 +121,7 @@ tables_body <- function(page, client_timezone, tables_rv, filtering_hint_ind) {
 
         dt <- DT::datatable(
             df,
-            extensions = c("Buttons", "FixedColumns", "Responsive"),
+            extensions = c("Buttons", "FixedColumns"),
             plugins = "diacritics-neutralise",
             options = list(pageLength = 30,
                            autoWidth = FALSE,
@@ -190,12 +193,14 @@ tables_body <- function(page, client_timezone, tables_rv, filtering_hint_ind) {
                           status = "info",
                           heading = HTML("<span class=\"glyphicon\">&#xe086;</span>Filtering"))),
                 div(class = "datatable_wrapper", dt),
-                width = 12
+                width = 12,
+                collapsible = FALSE
             )
         } else {
             bs4Card(
                 div(class = "datatable_wrapper", dt),
-                width = 12
+                width = 12,
+                collapsible = FALSE
             )
         }
     }


### PR DESCRIPTION
- Remove default collapsible behavior from all bs4Card components by explicitly setting collapsible =
  FALSE
- Remove Responsive DataTables extension to eliminate the row expand/collapse toggle on mobile
- Remove unused min-tablet-p column class now that the Responsive extension is no longer in use